### PR TITLE
exports on routes updated

### DIFF
--- a/controllers/api/commentRoutes.js
+++ b/controllers/api/commentRoutes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+
+router.get('/', (req, res) => {
+    console.log(req);
+    res.send('Comment request received.')
+});
+
+module.exports = router;

--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -1,10 +1,10 @@
 const router = require('express').Router();
 const postRoutes = require('./postRoutes');
 const commentRoutes = require('./commentRoutes');
-const userRoutes = require('/userRoutes');
+const userRoutes = require('./userRoutes');
 
 router.use('/posts', postRoutes);
 router.use('/comments', commentRoutes);
 router.use('/users', userRoutes);
 
-exports.router = router;
+module.exports = router;

--- a/controllers/api/postRoutes.js
+++ b/controllers/api/postRoutes.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+
+router.get('/', (req, res) => {
+    console.log(req);
+    res.send('Post request received.')
+});
+
+module.exports = router;

--- a/controllers/api/userRoutes.js
+++ b/controllers/api/userRoutes.js
@@ -1,4 +1,9 @@
 const router = require('express').Router();
 const bcrypt = require('bcrypt');
 
+router.get('/', (req, res) => {
+    console.log(req);
+    res.send('User request received.')
+});
+
 module.exports = router;

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -3,5 +3,5 @@ const apiRoutes = require('./api');
 
 router.use('/api', apiRoutes);
 
-exports.router = router;
+module.exports = router;
 

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -21,11 +21,11 @@ Comment.init(
             type: DataTypes.TEXT,
             allowNull: false,
         },
-        user_name: {
+        user_id: {
             type: DataTypes.STRING,
             references: {
                 model: 'user',
-                key: 'user_name',
+                key: 'id',
             }
         },
         post_id: {

--- a/models/Post.js
+++ b/models/Post.js
@@ -27,11 +27,11 @@ Post.init(
             type: DataTypes.TEXT,
             allowNull: false,
         },
-        user_name: {
+        user_id: {
             type: DataTypes.STRING,
             references: {
                 model: 'user',
-                key: 'user_name',
+                key: 'id',
             },
         },
     },

--- a/models/index.js
+++ b/models/index.js
@@ -5,19 +5,19 @@ const Comment = require('./Comment');
 const User = require('./User');
 
 User.hasMany(Post, {
-    foreignKey: 'user_name',    
+    foreignKey: 'user_id',    
 });
 
 Post.belongsTo(User, {
-    foreignKey: user_id,
+    foreignKey: 'user_id',
 });
 
 User.hasMany(Comment, {
-    foreignKey: 'user_name',
+    foreignKey: 'user_id',
 });
 
 Comment.belongsTo(User, {
-    foreignKey: 'user_name',
+    foreignKey: 'user_id',
 });
 
 // A post can potentially have many comments.  All comments will reference the post they

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const session = require('express-session');
-const controllers = require('./controllers');
+const routes = require('./controllers');
+const exphbs = require('express-handlebars');
 
 const sequelize = require('./config/connection');
 
@@ -10,9 +11,12 @@ const PORT = process.env.PORT || 7075;
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use(controllers);
+// app.engine('handlebars', hbs.engine);
+// app.set('view engine', 'handlebars');
 
-sequelize.sync ({ force: false })
+app.use(routes);
+
+sequelize.sync({ force: false })
     .then(() => {
         app.listen(PORT, () => console.log(`Listening on ${PORT}`));
     });


### PR DESCRIPTION
The syntax used to export routes has been corrected.  Testing revealed issues when using the previous syntax.  This was changed to allow the routes to properly export to the express application.  Another significant change in this PR is related to the foreign keys defined on the post and comment models.  Seeds were not populating correctly, and debugging revealed an issue related to the data types still being defined as strings.  The value in each model's foreign key was updated to use the Integer data type.  The data is properly seeding in all tables after this correction.